### PR TITLE
Fix plot_filetype key in parameters solution

### DIFF
--- a/episodes/parameters.md
+++ b/episodes/parameters.md
@@ -239,7 +239,7 @@ with content
 
 ```yaml
 plot_styles: "styles/poster.mplstyle"
-plot_format: ".svg"
+plot_filetype: ".svg"
 W0_reference: 0.2
 ```
 


### PR DESCRIPTION
## Summary
- Correct the solution config key from `plot_format` to `plot_filetype` in `episodes/parameters.md`.
- Keep the solution aligned with the earlier `config["plot_filetype"]` example in the same episode.

## Validation
- Confirmed `episodes/parameters.md` no longer contains `plot_format`.
- Confirmed the issue-described solution now uses `plot_filetype: ".svg"`.

Closes #10